### PR TITLE
Fix possbile deadlock caused by not reading stdout.

### DIFF
--- a/com.tsk.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/com.tsk.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -1031,7 +1031,6 @@ namespace VSCodeEditor
             {
                 FileName = dotnetCommand,
                 Arguments = "-c \"dotnet build\"",
-                RedirectStandardOutput = true,
                 UseShellExecute = false,
                 CreateNoWindow = true
             };


### PR DESCRIPTION
Redirecting and then not reading from stdout can cause a deadlock, when the stdout pipe buffer is too small.